### PR TITLE
Fix load failure when using ESM 'import'

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ p.close = function() {
 	this.child.kill();
 }
 
-if(!module.parent) {
+if(require && require.main === module) {
 	new MpgPlayer().play(process.argv[2]);
 }
 


### PR DESCRIPTION
When using 'import' and the ESM module loader, the module fails to load with:
```
mnt/compile/source/voice/pia/node_modules/mpg123/index.js:83
	this.track = file.substr(file.lastIndexOf('/')+1);
	                  ^
TypeError: Cannot read property 'substr' of undefined
```

This is because the check whether it's a module or started from the commandline doesn't work in this case. See https://stackoverflow.com/questions/6398196/detect-if-called-through-require-or-directly-by-command-line .

Use another check that is more correct and works also in this case.